### PR TITLE
Adds support for service accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ dfpUser.getService('LineItemService', function (lineItemService) {
 });
 ```
 
+### Service accounts example
+
+If you would like to use a Google [Service Account](https://developers.google.com/doubleclick-publishers/docs/service_accounts) to access DFP, you can do so by creating an instance of the JWT auth client.
+
+```JavaScript
+var google = require('googleapis')
+
+var jwtClient = new google.auth.JWT(
+  SERVICE_ACCOUNT_EMAIL,
+  'path/to/key.pem,
+  null,
+  ['https://www.googleapis.com/auth/dfp']);
+
+dfpUser.setClient(jwtClient)
+
+```
+
 
 Known Issues
 ------------

--- a/lib/DfpUser.js
+++ b/lib/DfpUser.js
@@ -1,7 +1,8 @@
 var
-  DEFAULT_VERSION = 'v201405',
+  DEFAULT_VERSION = 'v201502',
   BASE_API_URL = 'https://ads.google.com/apis/ads/publisher';
 
+var google = require('googleapis');
 
 var DfpUser = function (netCode, appName, version) {
 
@@ -12,9 +13,16 @@ var DfpUser = function (netCode, appName, version) {
   return this;
 };
 
+DfpUser.prototype.setClient = function (client) {
+  this.authClient = client;
+
+  return this;
+}
+
 
 DfpUser.prototype.setSettings = function (settings) {
   this.settings = settings;
+
   return this;
 };
 
@@ -42,7 +50,6 @@ DfpUser.prototype.getSOAPHeader = function () {
 DfpUser.prototype.getService = function (service, callback, version) {
 
   var soap = require('soap');
-  var Oath = require('googleapis').auth.OAuth2;
   var soap_wsdl;
   var dfpUser = this;
 
@@ -50,21 +57,13 @@ DfpUser.prototype.getService = function (service, callback, version) {
 
   soap_wsdl = BASE_API_URL + '/' + version + '/' + service + '?wsdl';
 
-  var oathClient = new Oath(this.settings.client_id, this.settings.client_secret, this.settings.redirect_url);
-  oathClient.credentials = { refresh_token: this.settings.refresh_token };
-
-  oathClient.refreshAccessToken(function (err, tokens) {
-
-    if (err) {
-      console.log('Refresh Token Error ' + err);
-      throw new Error('Unable to get token');
+  var options = {
+    ignoredNamespaces: {
+      namespaces: ['tns']
     }
+  };
 
-    var options = {
-     ignoredNamespaces: {
-       namespaces: ['tns']
-     }
-    };
+  this.getTokens(function (err, tokens) {
 
     soap.createClient(soap_wsdl, options, function (err, client) {
       if (err) {
@@ -93,11 +92,22 @@ DfpUser.prototype.getService = function (service, callback, version) {
       }
 
       return callback(serviceInstance);
-    });
 
+    });
   });
 
   return this;
+};
+
+DfpUser.prototype.getTokens = function (callback) {
+  if (this.authClient) {
+    return this.authClient.authorize(callback);
+  }
+
+  var oathClient = new google.auth.OAuth2(this.settings.client_id, this.settings.client_secret, this.settings.redirect_url);
+  oathClient.credentials = { refresh_token: this.settings.refresh_token };
+
+  oathClient.refreshAccessToken(callback);
 };
 
 


### PR DESCRIPTION
This allows passing an instance of a Google auth client to use for
adding the authentication info to the Soap calls.  So, it ends up
supporting service accounts but also should support any of the
other Google auth clients.