### PR TITLE
getService errback fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ You can instance any of DFP's API Services; https://developers.google.com/double
 
 
 ```JavaScript
-dfpUser.getService('LineItemService', function (lineItemService) {
+dfpUser.getService('LineItemService', function (err, lineItemService) {
+  if (err) {
+    return console.error(err);
+  }
 
   var statement = new DfpClass.Statement('WHERE id = 103207340');
 

--- a/examples/createCampaign.js
+++ b/examples/createCampaign.js
@@ -6,7 +6,12 @@ var dfpConfig = require('./dfpCredentials');
 var dfpUser = new Dfp.User(dfpConfig.networkCore, dfpConfig.applicationName);
 dfpUser.setSettings(dfpConfig);
 
-dfpUser.getService('OrderService', function (orderService) {
+dfpUser.getService('OrderService', function (err, orderService) {
+  if (err) {
+    console.error(err);
+    return false;
+  }
+
   var args = { orders: [{
       name: 'Full Campaign #67',
       notes: 'It cannot be this simple!',
@@ -21,7 +26,12 @@ dfpUser.getService('OrderService', function (orderService) {
     }
     console.log(myOrder);
 
-    dfpUser.getService('LineItemService', function (lineItemService) {
+    dfpUser.getService('LineItemService', function (err, lineItemService) {
+      if (err) {
+        console.error(err);
+        return false;
+      }
+
       var li = { lineItems: [{
         orderId: parseFloat(myOrder.rval[0].id),
         name: 'Lineitem descriptive name #10',
@@ -51,7 +61,12 @@ dfpUser.getService('OrderService', function (orderService) {
         }
         console.log(myLineItem);
 
-        dfpUser.getService('CreativeService', function (creativeService) {
+        dfpUser.getService('CreativeService', function (err, creativeService) {
+          if (err) {
+            console.error(err);
+            return false;
+          }
+
           var cr = { creatives: [{
             attributes: { 'xsi:type': 'ImageCreative' },  // Read Creative.Type - https://developers.google.com/doubleclick-publishers/docs/reference/v201403/CreativeService.BaseImageCreative
             advertiserId: '10209990',                     // Must correspond to an advertiserId in your DFP instance
@@ -75,7 +90,12 @@ dfpUser.getService('OrderService', function (orderService) {
             }
             console.log(myCreative);
 
-            dfpUser.getService('LineItemCreativeAssociationService', function (licaService) {
+            dfpUser.getService('LineItemCreativeAssociationService', function (err, licaService) {
+              if (err) {
+                console.error(err);
+                return false;
+              }
+
               var lica = { lineItemCreativeAssociations: [{
                 lineItemId: myLineItem.rval[0].id,
                 creativeId: myCreative.rval[0].id

--- a/examples/createOrders.js
+++ b/examples/createOrders.js
@@ -6,8 +6,12 @@ var dfpConfig = require('/dfpCredentials');
 var dfpUser = new Dfp.User(dfpConfig.networkCore, dfpConfig.applicationName);
 dfpUser.setSettings(dfpConfig);
 
-dfpUser.getService('OrderService', function (orderService) {
-  var args = { 
+dfpUser.getService('OrderService', function (err, orderService) {
+  if (err) {
+    return console.error(err);
+  }
+
+  var args = {
     orders: [
       {
         name: 'Multiple NodeJS Order Creation #1',

--- a/examples/listLineitems.js
+++ b/examples/listLineitems.js
@@ -6,7 +6,10 @@ var dfpConfig = require('./dfpCredentials');
 var dfpUser = new Dfp.User(dfpConfig.networkCore, dfpConfig.applicationName);
 dfpUser.setSettings(dfpConfig);
 
-dfpUser.getService('LineItemService', function (lineItemService) {
+dfpUser.getService('LineItemService', function (err, lineItemService) {
+  if (err) {
+    return console.error(err);
+  }
 
   var query = new Dfp.Statement('LIMIT 10');
 

--- a/examples/runReport.js
+++ b/examples/runReport.js
@@ -6,7 +6,10 @@ var dfpConfig = require('./dfpCredentials');
 var dfpUser = new Dfp.User(dfpConfig.networkCore, dfpConfig.applicationName);
 dfpUser.setSettings(dfpConfig);
 
-dfpUser.getService('ReportService', function (reportService) {
+dfpUser.getService('ReportService', function (err, reportService) {
+  if (err) {
+    return console.error(err);
+  }
 
   var results = null;
   var args = {

--- a/lib/DfpUser.js
+++ b/lib/DfpUser.js
@@ -53,17 +53,30 @@ DfpUser.prototype.getService = function (service, callback, version) {
     }
   };
 
+  // If the callback accepts two arguments, make note that we should pass errors
+  // to the callback.
+  //
+  var callbackSupportsError = callback.length === 2;
+
   this.getTokens(function (err, tokens) {
 
     if (err) {
       console.log('getTokens Error ' + err);
-      return callback(new Error('getTokens Error'));
+      var error = new Error('getTokens Error');
+      if (callbackSupportsError) {
+        return callback(error);
+      }
+      throw error;
     }
 
     soap.createClient(soap_wsdl, options, function (err, client) {
       if (err) {
         console.log('Create Client Error ' + err);
-        return callback(new Error('Unable to get token'));
+        var error = new Error('Unable to get token');
+        if (callbackSupportsError) {
+          return callback(error);
+        }
+        throw error;
       }
 
       client.addSoapHeader(dfpUser.getSOAPHeader(), '', '', '');
@@ -88,8 +101,10 @@ DfpUser.prototype.getService = function (service, callback, version) {
         }
       }
 
-      return callback(null, serviceInstance);
-
+      if (callbackSupportsError) {
+        return callback(null, serviceInstance);
+      }
+      callback(serviceInstance);
     });
   });
 

--- a/lib/DfpUser.js
+++ b/lib/DfpUser.js
@@ -57,13 +57,13 @@ DfpUser.prototype.getService = function (service, callback, version) {
 
     if (err) {
       console.log('getTokens Error ' + err);
-      throw new Error('getTokens Error');
+      return callback(new Error('getTokens Error'));
     }
 
     soap.createClient(soap_wsdl, options, function (err, client) {
       if (err) {
         console.log('Create Client Error ' + err);
-        throw new Error('Unable to get token');
+        return callback(new Error('Unable to get token'));
       }
 
       client.addSoapHeader(dfpUser.getSOAPHeader(), '', '', '');
@@ -88,7 +88,7 @@ DfpUser.prototype.getService = function (service, callback, version) {
         }
       }
 
-      return callback(serviceInstance);
+      return callback(null, serviceInstance);
 
     });
   });


### PR DESCRIPTION
Changes the `DfpUser.prototype.getService` api to accept a node-style callback to make error handling possible.

This is a breaking change for existing users. If you're concerned about this, I can tweak this to support single-argument callbacks as well. If you're ok with the breaking change, not sure if you want to increment the major version or not since you're not yet 1.0.

Addresses issue https://github.com/ShinyAds/node-google-dfp/issues/17.