### PR TITLE
ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Adds a `.gitignore` so that node modules will not get included.

Since the node modules are not git committed, it might be good to also have a section in the readme for getting set up that specifies that you need to run `npm install`.