### PR TITLE
Upgrade Dependencies

### DIFF
--- a/lib/DfpUser.js
+++ b/lib/DfpUser.js
@@ -38,7 +38,6 @@ DfpUser.prototype.getSOAPHeader = function () {
 };
 
 DfpUser.prototype.getService = function (service, callback, version) {
-
   var soap = require('soap');
   var soap_wsdl;
   var dfpUser = this;
@@ -116,11 +115,9 @@ DfpUser.prototype.getTokens = function (callback) {
     return this.authClient.authorize(callback);
   }
 
-  var oathClient = new google.auth.OAuth2(this.settings.client_id, this.settings.client_secret, this.settings.redirect_url);
-  oathClient.credentials = { refresh_token: this.settings.refresh_token };
-
-  oathClient.refreshAccessToken(callback);
+  var oauthClient = new google.auth.OAuth2(this.settings.client_id, this.settings.client_secret, this.settings.redirect_url);
+  oauthClient.setCredentials({ refresh_token: this.settings.refresh_token });
+  oauthClient.refreshAccessToken(callback);
 };
-
 
 module.exports = DfpUser;

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "jasmine-node": "1.14.5"
   },
   "dependencies": {
-    "googleapis": "^0.7.0",
-    "soap": "^0.11.1"
+    "googleapis": "^4.0.0",
+    "soap": "^0.14.0"
   },
   "scripts": {
     "test": "grunt all"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "googleapis": "^4.0.0",
-    "soap": "^0.14.0"
+    "soap": "^0.13.0"
   },
   "scripts": {
     "test": "grunt all"

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Google DFP API Helper Library for NodeJS",
   "main": "index.js",
   "devDependencies": {
-    "grunt": "^0.4.4",
+    "grunt": "^1.0.0",
     "grunt-jasmine-node": "^0.3.1",
-    "grunt-contrib-jshint": "^0.10.0",
+    "grunt-contrib-jshint": "^1.0.0",
     "jasmine-node": "1.14.5"
   },
   "dependencies": {


### PR DESCRIPTION
I have upgraded the dependency versions for `soap` and `googleapis` to the latest to resolve a few security vulnerabilities found in a [nsp](https://nodesecurity.io/tools) scan. These vulnerabilities were found in the `qs` and `hawk` packages used in an older version of `googleapis`. In this PR, they are resolved. I have also updated the usage of oauth2 credentials in DfpUser. 

```
⇒ nsp check
(+) 3 vulnerabilities found

Denial-of-Service Extended Event Loop Blocking
Name: qs
Installed: 0.6.6
Vulnerable: <1.0.0
Patched: >= 1.x
Path: node-google-dfp@0.2.1 > googleapis@0.7.0 > request@2.34.0 > qs@0.6.6
More Info: https://nodesecurity.io/advisories/28

Denial-of-Service Memory Exhaustion
Name: qs
Installed: 0.6.6
Vulnerable: <1.0.0
Patched: >= 1.x
Path: node-google-dfp@0.2.1 > googleapis@0.7.0 > request@2.34.0 > qs@0.6.6
More Info: https://nodesecurity.io/advisories/29

Regular Expression Denial of Service
Name: hawk
Installed: 1.0.0
Vulnerable: < 3.1.3  || >= 4.0.0 <4.1.1
Patched: >=3.1.3 < 4.0.0 || >=4.1.1
Path: node-google-dfp@0.2.1 > googleapis@0.7.0 > request@2.34.0 > hawk@1.0.0
More Info: https://nodesecurity.io/advisories/77
```

After:

```
⇒ nsp check
(+) No known vulnerabilities found
```

🎉 

