### PR TITLE
Add a user-agent to the application name.

### DIFF
--- a/lib/DfpUser.js
+++ b/lib/DfpUser.js
@@ -1,11 +1,13 @@
 var DEFAULT_VERSION = 'v201602',
   BASE_API_URL    = 'https://ads.google.com/apis/ads/publisher',
-  google          = require('googleapis');
+  google          = require('googleapis'),
+  packageVersion  = require('../package.json').version;
 
 function DfpUser(netCode, appName, version) {
   this.networkCode = netCode;
   this.applicationName = appName;
   this.version = version || DEFAULT_VERSION;
+  this.userAgent = "(DfpApi-Nodejs, ShinyAds/" + packageVersion + ", node/" + process.versions.node + ")";
 
   return this;
 }
@@ -32,7 +34,7 @@ DfpUser.prototype.getSOAPHeader = function () {
         'xmlns:soapenv'           : "http://schemas.xmlsoap.org/soap/envelope/"
       },
       'ns1:networkCode'     : this.networkCode,
-      'ns1:applicationName' : this.applicationName
+      'ns1:applicationName' : this.applicationName + " " + this.userAgent
     }
   };
 };

--- a/spec/DfpUser-spec.js
+++ b/spec/DfpUser-spec.js
@@ -33,7 +33,7 @@ describe("DfpUser", function () {
       expect(header.RequestHeader.attributes['xmlns:xsi']).toBe('http://www.w3.org/2001/XMLSchema-instance');
       expect(header.RequestHeader.attributes['xmlns:soapenv']).toBe('http://schemas.xmlsoap.org/soap/envelope/');
       expect(header.RequestHeader['ns1:networkCode']).toBe(dfpSetup.networkCode);
-      expect(header.RequestHeader['ns1:applicationName']).toBe(dfpSetup.applicationName);
+      expect(header.RequestHeader['ns1:applicationName']).toBe(dfpSetup.applicationName + " " + dfpSetup.userAgent);
     });
   });
 });


### PR DESCRIPTION
Adds a user-agent to the application name in the SOAP header, in the
format:
(DfpApi-Language LibraryName/library.version LanguageFramework/language.version)

This is the same format used by the [googleads](https://github.com/googleads/) libraries, and provides
context when debugging or identifying API applications.